### PR TITLE
Add cache functionality to frontend service

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ This is all being handled by the Bicep template in this repository, so no need t
 To deploy this solution you need to create a service principal in Azure which has the appropriate roles to create resource groups, all resources and set permissions (RBAC) to all these resources. The easiest way to set this up is by using the `Owner` role, as it has enough permissions to apply roles. However, keep in mind, this grants the service principal a lot of power on the entire subscription.
 
 ```azcli
-az ad sp create-for-rbac --name "minifier" --role owner --sdk-auth
+az ad sp create-for-rbac --name "minifier" --role owner --scopes /subscriptions/{subscriptionId} --sdk-auth
 ```
 
 What I'm doing to limit this is to make this service principal a `Contributor`, which still grants it a lot of power, and applying the `Owner` role to the created resource group after the first (failed) deployment.

--- a/README.md
+++ b/README.md
@@ -106,12 +106,15 @@ The contents of the `Minifier.Frontend` project should look similar to the follo
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "UrlMinifierRepository__accountEndpoint": "https://{yourCosmosDbAccountName}.documents.azure.com:443/",
     "UrlMinifierRepository__DatabaseName": "minifier", // This one is defined in the Bicep template, but you can change it if you want.
-    "UrlMinifierRepository__CollectionName": "urls" // This one is defined in the Bicep template, but you can change it if you want.
+    "UrlMinifierRepository__CollectionName": "urls", // This one is defined in the Bicep template, but you can change it if you want.
+    "MinifierIncomingMessages__fullyQualifiedNamespace": "{yourServiceBusNamespaceName}.servicebus.windows.net",
+    "IncomingUrlsTopicName": "incoming-minified-urls", // This one is defined in the Bicep template, but you can change it if you want.
+    "IncomingUrlsProcessingSubscription": "updatefrontendweu" // This one is defined in the Bicep template, but you can change it if you want.
   }
 }
 ```
 
-To get the necessary Azure resources, run the following Azure CLI commands:
+To get the necessary Azure resources, run the following Azure CLI commands in the folder `./deployment/infrastructure/`:
 
 ```azcli
 az deployment sub create --location WestEurope --template-file basic-infrastructure.bicep --parameters parameters.lcl.json

--- a/deployment/infrastructure/ServiceBus/subscription.bicep
+++ b/deployment/infrastructure/ServiceBus/subscription.bicep
@@ -15,3 +15,5 @@ resource subscription 'Microsoft.ServiceBus/namespaces/topics/subscriptions@2021
   name: name
   parent: topic
 }
+
+output name string = subscription.name

--- a/deployment/infrastructure/application-infrastructure.bicep
+++ b/deployment/infrastructure/application-infrastructure.bicep
@@ -13,6 +13,7 @@ param backendPackageReferenceLocation string
 param fullDomainName string
 
 param serviceBusNamespaceName string
+param serviceBusUpdateFrontendTopicSubscriptionNamePrefix string
 param databaseAccountName string
 param sqlDatabaseName string
 param slugContainerName string
@@ -172,6 +173,18 @@ resource config 'Microsoft.Web/sites/config@2020-12-01' = {
       {
         name: 'UrlMinifierRepository__CollectionName'
         value: slugContainerName
+      }
+      {
+        name: 'MinifierIncomingMessages__fullyQualifiedNamespace'
+        value: '${serviceBusNamespaceName}.servicebus.windows.net'
+      }
+      {
+        name: 'IncomingUrlsTopicName'
+        value: serviceBusIncomingMinifiedUrlsTopicName
+      }
+      {
+        name: 'IncomingUrlsProcessingSubscription'
+        value: '${serviceBusUpdateFrontendTopicSubscriptionNamePrefix}${azureRegion}'
       }
     ]
   }

--- a/deployment/infrastructure/application-services.bicep
+++ b/deployment/infrastructure/application-services.bicep
@@ -67,10 +67,10 @@ module processSubscription 'ServiceBus/subscription.bicep' = {
   }
 }
 
-module invalidateSubscription 'ServiceBus/subscription.bicep' = {
-  name: 'invalidateSubscription'
+module updatefrontendSubscription 'ServiceBus/subscription.bicep' = {
+  name: 'updatefrontendSubscription'
   params: {
-    name: 'invalidate${azureRegion}'
+    name: 'updatefrontend${azureRegion}'
     namespaceName: serviceBusNamespace.outputs.name
     topicName: topic.outputs.name
   }

--- a/deployment/infrastructure/application-services.bicep
+++ b/deployment/infrastructure/application-services.bicep
@@ -80,3 +80,4 @@ output databaseAccountName string = databaseAccount.outputs.accountName
 output slugContainerName string = slugContainer.outputs.name
 output sqlDatabaseName string = sqlDatabase.outputs.databaseName
 output serviceBusNamespaceName string = serviceBusNamespace.outputs.name
+output serviceBusIncomingUrlTopicName string = serviceBusIncomingMinifiedUrlsTopicName

--- a/deployment/infrastructure/main.bicep
+++ b/deployment/infrastructure/main.bicep
@@ -31,6 +31,7 @@ var regionWestEuropeName = 'weu'
 var regionWestUsName = 'wus'
 var regionAustraliaSouthEastName = 'aus'
 var fullDomainName = '${subdomain}.${hostname}'
+var serviceBusUpdateFrontendTopicSubscriptionNamePrefix = 'updatefrontend'
 
 targetScope = 'subscription'
 
@@ -63,6 +64,16 @@ module applicationServices 'application-services.bicep' = {
   }
 }
 
+module servicebusSubscriptions 'ServiceBus/subscription.bicep' = [for region in [regionAustraliaSouthEastName, regionWestEuropeName, regionWestUsName]: {
+  scope: rgWestEurope
+  name: '${systemName}${region}-update-cache-subscriptions'
+  params: {
+    name: '${serviceBusUpdateFrontendTopicSubscriptionNamePrefix}${region}'
+    namespaceName: applicationServices.outputs.serviceBusNamespaceName
+    topicName: applicationServices.outputs.serviceBusIncomingUrlTopicName
+  }
+}]
+
 module applicationWestEurope 'application-infrastructure.bicep' = {
   name: '${systemName}${regionWestEuropeName}-apps'
   params: {
@@ -74,6 +85,7 @@ module applicationWestEurope 'application-infrastructure.bicep' = {
     fullDomainName: fullDomainName
     databaseAccountName: applicationServices.outputs.databaseAccountName
     serviceBusNamespaceName: applicationServices.outputs.serviceBusNamespaceName
+    serviceBusUpdateFrontendTopicSubscriptionNamePrefix: serviceBusUpdateFrontendTopicSubscriptionNamePrefix
     slugContainerName: applicationServices.outputs.slugContainerName
     sqlDatabaseName: applicationServices.outputs.sqlDatabaseName
   }
@@ -102,6 +114,7 @@ module applicationWestUs 'application-infrastructure.bicep' = {
     fullDomainName: fullDomainName
     databaseAccountName: applicationServices.outputs.databaseAccountName
     serviceBusNamespaceName: applicationServices.outputs.serviceBusNamespaceName
+    serviceBusUpdateFrontendTopicSubscriptionNamePrefix: serviceBusUpdateFrontendTopicSubscriptionNamePrefix
     slugContainerName: applicationServices.outputs.slugContainerName
     sqlDatabaseName: applicationServices.outputs.sqlDatabaseName
   }
@@ -133,6 +146,7 @@ module applicationAustraliaSouthEast 'application-infrastructure.bicep' = {
     fullDomainName: fullDomainName
     databaseAccountName: applicationServices.outputs.databaseAccountName
     serviceBusNamespaceName: applicationServices.outputs.serviceBusNamespaceName
+    serviceBusUpdateFrontendTopicSubscriptionNamePrefix: serviceBusUpdateFrontendTopicSubscriptionNamePrefix
     slugContainerName: applicationServices.outputs.slugContainerName
     sqlDatabaseName: applicationServices.outputs.sqlDatabaseName
   }

--- a/src/Minifier.Frontend/Configuration.cs
+++ b/src/Minifier.Frontend/Configuration.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Minifier.Frontend 
+{
+    internal class Configuration 
+    {
+        public UrlMinifierRepository UrlMinifierRepository { get; } = new UrlMinifierRepository();
+    }
+
+    internal class UrlMinifierRepository 
+    {
+        public string DatabaseName { get; } = Environment.GetEnvironmentVariable($"{nameof(UrlMinifierRepository)}__{nameof(DatabaseName)}", EnvironmentVariableTarget.Process);
+        public string CollectionName { get; } = Environment.GetEnvironmentVariable($"{nameof(UrlMinifierRepository)}__{nameof(CollectionName)}", EnvironmentVariableTarget.Process);
+    }
+}

--- a/src/Minifier.Frontend/Get.cs
+++ b/src/Minifier.Frontend/Get.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Minifier.Frontend
@@ -10,6 +11,8 @@ namespace Minifier.Frontend
     public class Get
     {
         private readonly ILogger<Get> logger;
+
+        private static Dictionary<string, string> _localCache = new Dictionary<string, string>();
 
         public Get(ILogger<Get> logger)
         {
@@ -30,7 +33,17 @@ namespace Minifier.Frontend
         {
             return new RedirectResult(existingMinifiedUrlEntity.url);
         }
-        
+
+        [FunctionName(nameof(UpdateLocalCache))]
+        public void UpdateLocalCache(
+            [ServiceBusTrigger("%IncomingUrlsTopicName%", "%UpdateFrontendSubscription%", Connection = "MinifierIncomingMessages")]
+            MinifiedUrl incomingCreateMinifiedUrlCommand
+            )
+        {
+            _localCache[incomingCreateMinifiedUrlCommand.Slug] = incomingCreateMinifiedUrlCommand.Url;
+            this.logger.LogInformation("Upserted {slug} with {url} to the local cache.", incomingCreateMinifiedUrlCommand.Slug, incomingCreateMinifiedUrlCommand.Url);
+        }
+
         /// <summary>
         /// Lowercasing this property, because Cosmos DB is case sensitive about properties
         /// and using the output binding, like in this Azure Function, doesn't work appear
@@ -39,6 +52,14 @@ namespace Minifier.Frontend
         public class MinifiedUrlEntity
         {
             public string url { get; set; }
+        }
+
+        public class MinifiedUrl
+        {
+            [JsonPropertyName("slug")]
+            public string Slug { get; set; }
+            [JsonPropertyName("url")]
+            public string Url { get; set; }
         }
     }
 }

--- a/src/Minifier.Frontend/Get.cs
+++ b/src/Minifier.Frontend/Get.cs
@@ -11,87 +11,105 @@ using System.Threading.Tasks;
 
 namespace Minifier.Frontend
 {
-    public class Get
-    {
-        private readonly Configuration configuration;
-        private readonly ILogger<Get> logger;
+	public class Get
+	{
+		private readonly Configuration configuration;
+		private readonly ILogger<Get> logger;
 
-        private static Dictionary<string, string> _localCache = new Dictionary<string, string>();
+		private static Dictionary<string, string> localCache = new Dictionary<string, string>();
 
-        public Get(
-            ILogger<Get> logger)
-        {
-            this.configuration = new Configuration();
-            this.logger = logger;
-        }
+		public Get(
+			ILogger<Get> logger)
+		{
+			this.configuration = new Configuration();
+			this.logger = logger;
+		}
 
-        [FunctionName(nameof(Get))]
-        public async Task<IActionResult> Run(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "{slug}")]
-            HttpRequest req,
-            string slug,
-            [CosmosDB(
-                databaseName: "%UrlMinifierRepository:DatabaseName%",
-                containerName: "%UrlMinifierRepository:CollectionName%",
-                Connection = "UrlMinifierRepository"
-                )]
-            CosmosClient client)
-        {
-            var container = client.GetContainer(
-                                    this.configuration.UrlMinifierRepository.DatabaseName, 
-                                    this.configuration.UrlMinifierRepository.CollectionName);
+		[FunctionName(nameof(Get))]
+		public async Task<IActionResult> Run(
+			[HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "{slug}")]
+			HttpRequest req,
+			string slug,
+			[CosmosDB(
+				databaseName: "%UrlMinifierRepository:DatabaseName%",
+				containerName: "%UrlMinifierRepository:CollectionName%",
+				Connection = "UrlMinifierRepository"
+				)]
+			CosmosClient client)
+		{
+			string foundMinifiedUrl = default(string);
+			if (localCache.ContainsKey(slug))
+			{
+				foundMinifiedUrl = Get.localCache[slug];
+				this.logger.LogInformation("Retrieved `{slug}` from cache.", slug);
+			}
+			else
+			{
+				foundMinifiedUrl = await FindUrlFromRepository(slug, client);
+				localCache[slug] = foundMinifiedUrl;
+				this.logger.LogInformation("Added `{slug}` to cache.", slug);
+			}
 
-            var queryDefinition = new QueryDefinition(
-                "SELECT u.url FROM urls u WHERE u.id = @slug")
-                .WithParameter("@slug", slug);
-            var queryRequestOptions = new QueryRequestOptions { PartitionKey = new PartitionKey(slug) };
+			if (foundMinifiedUrl == null)
+			{
+				return new NotFoundResult();
+			}
+			return new RedirectResult(foundMinifiedUrl);
+		}
 
-            string foundMinifiedUrl = default;
-            using (var resultSet = container.GetItemQueryIterator<MinifiedUrlEntity>(
-                                                                    queryDefinition, 
-                                                                    requestOptions: queryRequestOptions)) 
-            {
-                while (resultSet.HasMoreResults) 
-                {
-                    var response = await resultSet.ReadNextAsync();
-                    foundMinifiedUrl = response.First()?.url;
-                    break;
-                }
-            }
+		private async Task<string> FindUrlFromRepository(string slug, CosmosClient client)
+		{
+			var container = client.GetContainer(
+												this.configuration.UrlMinifierRepository.DatabaseName,
+												this.configuration.UrlMinifierRepository.CollectionName);
 
-            if(foundMinifiedUrl == null)
-            {
-                return new NotFoundResult();
-            }
-            return new RedirectResult(foundMinifiedUrl);
-        }
+			var queryDefinition = new QueryDefinition(
+				"SELECT u.url FROM urls u WHERE u.id = @slug")
+				.WithParameter("@slug", slug);
+			var queryRequestOptions = new QueryRequestOptions { PartitionKey = new PartitionKey(slug) };
 
-        [FunctionName(nameof(UpdateLocalCache))]
-        public void UpdateLocalCache(
-            [ServiceBusTrigger("%IncomingUrlsTopicName%", "%IncomingUrlsProcessingSubscription%", Connection = "MinifierIncomingMessages")]
-            MinifiedUrl incomingCreateMinifiedUrlCommand
-            )
-        {
-            _localCache[incomingCreateMinifiedUrlCommand.Slug] = incomingCreateMinifiedUrlCommand.Url;
-            this.logger.LogInformation("Upserted {slug} with {url} to the local cache.", incomingCreateMinifiedUrlCommand.Slug, incomingCreateMinifiedUrlCommand.Url);
-        }
+			string foundMinifiedUrl = default;
+			using (var resultSet = container.GetItemQueryIterator<MinifiedUrlEntity>(
+																	queryDefinition,
+																	requestOptions: queryRequestOptions))
+			{
+				while (resultSet.HasMoreResults)
+				{
+					var response = await resultSet.ReadNextAsync();
+					foundMinifiedUrl = response.First()?.url;
+					break;
+				}
+			}
 
-        /// <summary>
-        /// Lowercasing this property, because Cosmos DB is case sensitive about properties
-        /// and using the output binding, like in this Azure Function, doesn't work appear
-        /// to work with <see cref="JsonPropertyNameAttribute"/> definitions.
-        /// </summary>
-        public class MinifiedUrlEntity
-        {
-            public string url { get; set; }
-        }
+			return foundMinifiedUrl;
+		}
 
-        public class MinifiedUrl
-        {
-            [JsonPropertyName("slug")]
-            public string Slug { get; set; }
-            [JsonPropertyName("url")]
-            public string Url { get; set; }
-        }
-    }
+		[FunctionName(nameof(UpdateLocalCache))]
+		public void UpdateLocalCache(
+			[ServiceBusTrigger("%IncomingUrlsTopicName%", "%IncomingUrlsProcessingSubscription%", Connection = "MinifierIncomingMessages")]
+			MinifiedUrl incomingCreateMinifiedUrlCommand
+			)
+		{
+			localCache[incomingCreateMinifiedUrlCommand.Slug] = incomingCreateMinifiedUrlCommand.Url;
+			this.logger.LogInformation("Upserted {slug} with {url} to the local cache.", incomingCreateMinifiedUrlCommand.Slug, incomingCreateMinifiedUrlCommand.Url);
+		}
+
+		/// <summary>
+		/// Lowercasing this property, because Cosmos DB is case sensitive about properties
+		/// and using the output binding, like in this Azure Function, doesn't work appear
+		/// to work with <see cref="JsonPropertyNameAttribute"/> definitions.
+		/// </summary>
+		public class MinifiedUrlEntity
+		{
+			public string url { get; set; }
+		}
+
+		public class MinifiedUrl
+		{
+			[JsonPropertyName("slug")]
+			public string Slug { get; set; }
+			[JsonPropertyName("url")]
+			public string Url { get; set; }
+		}
+	}
 }

--- a/src/Minifier.Frontend/Minifier.Frontend.csproj
+++ b/src/Minifier.Frontend/Minifier.Frontend.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="4.0.0-preview3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Instead of hammering the Cosmos DB when URLs go viral, the URLs are stored in-memory.
This will mark #16 as done.

Backend will send message to a Service Bus Topic, where the Process in the Backend is subscribed on and the UpdateLocalCache in the Frontend.